### PR TITLE
File Pathing Issues Fix

### DIFF
--- a/src/NetworkMap.cpp
+++ b/src/NetworkMap.cpp
@@ -9,7 +9,7 @@ sf::Vector2i lastPos;
 
 NetworkMap::NetworkMap(const std::vector<Host>& hosts) : hosts(hosts) {
     view = sf::View(sf::FloatRect(0, 0, 800, 600));
-    loadFont("../fonts/Roboto-Regular.ttf");
+    loadFont("fonts/Roboto-Regular.ttf");
     calculatePanLimits();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 int main() {
     try {
         NmapParser parser;
-        std::vector<Host> hosts = parser.parseNmapXML("/home/fedora12/CLionProjects/nmap_project/output/nmap_output.xml");
+        std::vector<Host> hosts = parser.parseNmapXML("output/nmap_output.xml");
 
         if (hosts.empty()) {
             std::cerr << "No hosts found in the Nmap XML file. Exiting..." << std::endl;


### PR DESCRIPTION
Set the main working directory of the project to "nmap_project".

Set file path to relative for fonts and output file.